### PR TITLE
Fixed memory locking

### DIFF
--- a/lab1/main.c
+++ b/lab1/main.c
@@ -38,6 +38,7 @@ struct MyMutex mutex1;
 
 // Globals! Achtung! Keep your children away!
 int counter = 0;
+// _Atomic int counter = 0; we can use _Atomic type instead of mutexes
 int result = 0;
 const int ITERATIONS_NUMBER = 1E6;
 

--- a/lab1/main.c
+++ b/lab1/main.c
@@ -41,7 +41,7 @@ int counter = 0;
 int result = 0;
 const int ITERATIONS_NUMBER = 1E6;
 
-main()
+int main()
 {
     int rc1, rc2;
     int i;
@@ -83,20 +83,18 @@ main()
 void *functionC()
 {
     /*
-    // Funny Mutex locking
-    while (my_mute == 1);
-    my_mute = 1;
+        Locking thread makes not sense. In this case program behaivoring the same as:
+            for(int i=0; i< threadsNumber; i++) {functionC();}
+        Locking around global variable `counter` more accurate solution.
     */
-    LOCK_MUTEX(&mutex1);
 
     int i = 0;
     while (i < ITERATIONS_NUMBER) {
+        LOCK_MUTEX(&mutex1);
         counter++;
+        UNLOCK_MUTEX(&mutex1);
         i++;
     }
     printf("Counter value: %d\n",counter);
     result += counter;
-    // Funny Mutex unlocking
-    //my_mute = 0;
-    UNLOCK_MUTEX(&mutex1);
 }


### PR DESCRIPTION
- Нету смысла в блокировке целого потока. В таком случае каждый поток будет отрабатывать по очереди. Идея в том, что бы блокировать общую память. В данном случае переменную `count`. Таким образом мы разграничиваем использование этой переменной потоками.
- С проседаниями `count` проблема в том, что операция инкремента (`count++;`)  не является атомарной. Потоки неуправляемо считывают и записывают туда свои вычисленные значения. Иногда считанное значение может скешироваться и инкрементироваться там же. Не успев записать вычисленное значение в переменную, второй поток считает "старое" значение переменной. Таким образом они поперезаписывают друг друга и значение `count` просядет. Таким образом контролировать память, которую используют 2 и больше потоков невозможно. Для этого используются `mutex` или `_Atomic`.
